### PR TITLE
Prevent use of null handler

### DIFF
--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -379,6 +379,10 @@ INT64 WinToast::showToast(_In_ const WinToastTemplate& toast, _In_  IWinToastHan
         DEBUG_MSG("Error when launching the toast. WinToast is not initialized =(");
         return id;
     }
+    if (!handler) {
+        DEBUG_MSG("Error when launching the toast. handler cannot be null.");
+        return id;
+    }
 
     HRESULT hr = _notificationManager->GetTemplateContent(ToastTemplateType(toast.type()), &_xmlDocument);
     if (SUCCEEDED(hr)) {


### PR DESCRIPTION
Use of a null handler isn't immediately fatal. However it will eventually lead to a crash. This enforces correct usage.