### PR TITLE
Ensure COM is initialized before use

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Import the header file wintoastlib.h to your project. Check if the current OS su
 using namespace WinToastLib;
 ....
 if (WinToast::isCompatible()) {
-std::wcout << L"Error, your system in not supported!" << std::endl;
+    std::wcout << L"Error, your system in not supported!" << std::endl;
 }
 ```
 
@@ -62,7 +62,7 @@ Check if the WinToas is initialized with succes & is compatible with your curren
 Now, implement your own handler subclassing the interface `IWinToastHandler`:
 
 ```cpp
-class WinToastHandlerExample : public WinToastHandler {
+class WinToastHandlerExample : public IWinToastHandler {
  public:
 	WinToastHandlerExample(); 
 	// Public interfaces

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -224,15 +224,19 @@ bool WinToast::isCompatible() {
                 || (DllImporter::WindowsDeleteString == nullptr));
 }
 
-std::wstring WinToast::configureAUMI(_In_ const std::wstring &company,
-                                               _In_ const std::wstring &name,
-                                               _In_ const std::wstring &surname,
-                                               _In_ const std::wstring &versionInfo)
+std::wstring WinToast::configureAUMI(_In_ const std::wstring &companyName,
+                                               _In_ const std::wstring &productName,
+                                               _In_ const std::wstring &subProduct,
+                                               _In_ const std::wstring &versionInformation)
 {
-    std::wstring aumi = company;
-    aumi += L"." + name;
-    aumi += L"." + surname;
-    aumi += L"." + versionInfo;
+    std::wstring aumi = companyName;
+    aumi += L"." + productName;
+    if (subProduct.length() > 0) {
+        aumi += L"." + subProduct;
+        if (versionInformation.length() > 0) {
+            aumi += L"." + versionInformation;
+        }
+    }
 
     if (aumi.length() > SCHAR_MAX) {
         DEBUG_MSG("Error: max size allowed for AUMI: 128 characters.");

--- a/src/wintoastlib.h
+++ b/src/wintoastlib.h
@@ -93,6 +93,7 @@ namespace WinToastLib {
         void                    setAppName(_In_ const std::wstring& appName);
     protected:
         bool											_isInitialized;
+        bool                                            _hasCoInitialized;
         std::wstring                                    _appName;
         std::wstring                                    _aumi;
         std::map<INT64, ComPtr<IToastNotification>>     _buffer;

--- a/src/wintoastlib.h
+++ b/src/wintoastlib.h
@@ -77,10 +77,10 @@ namespace WinToastLib {
         virtual ~WinToast();
         static WinToast* instance();
         static bool             isCompatible();
-        static std::wstring     configureAUMI(_In_ const std::wstring& company,
-                                                    _In_ const std::wstring& name,
-                                                    _In_ const std::wstring& surname,
-                                                    _In_ const std::wstring& versionInfo
+        static std::wstring     configureAUMI(_In_ const std::wstring& companyName,
+                                                    _In_ const std::wstring& productName,
+                                                    _In_ const std::wstring& subProduct = std::wstring(),
+                                                    _In_ const std::wstring& versionInformation = std::wstring()
                                                     );
         virtual bool            initialize();
         virtual bool            isInitialized() const { return _isInitialized; }


### PR DESCRIPTION
COM [must be initialized](https://msdn.microsoft.com/en-us/library/windows/desktop/ff485844(v=vs.85).aspx) before use or the Toast API calls will fail.

I have also improved the AUMI configuration. Now the part names are equivalent to [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx#how) and the last two parts are optional.