### PR TITLE
No toast means no success

### DIFF
--- a/example/qt-gui-example/WinToastExample/mainwindow.cpp
+++ b/example/qt-gui-example/WinToastExample/mainwindow.cpp
@@ -68,7 +68,7 @@ void MainWindow::on_showToast_clicked()
     templ.setTextField(ui->secondLine->text().toStdWString(), WinToastTemplate::SecondLine);
     templ.setTextField(ui->secondLine->text().toStdWString(), WinToastTemplate::ThirdLine);
 
-    if (!WinToast::instance()->showToast(templ, new CustomHandler())) {
+    if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {
         QMessageBox::warning(this, "Error", "Could not launch your toast notification!");
     }
 }

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -428,14 +428,14 @@ INT64 WinToast::showToast(_In_ const WinToastTemplate& toast, _In_  IWinToastHan
                         if (SUCCEEDED(hr)) {
                             id = guid.Data1;
                             _buffer[id] = notification;
-                            _notifier->Show(notification.Get());
+                            hr = _notifier->Show(notification.Get());
                         }
                     }
                 }
             }
         }
     }
-    return id;
+    return FAILED(hr) ? -1 : id;
 }
 
 bool WinToast::hideToast(_In_ INT64 id) {


### PR DESCRIPTION
The example as well as the library code need minor adjustments to show the warning reliably that the toast could not be shown.