### PR TITLE
Provide a way to only create the shortcut

### DIFF
--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -48,9 +48,10 @@ int wmain(int argc, LPWSTR *argv)
         return 6;
     }
 
-    LPWSTR appName = L"Console WinToast Example", appUserModelID = L"WinToast Console Example", text = L"Hello, world!", imagePath = NULL;
+    LPWSTR appName = L"Console WinToast Example", appUserModelID = L"WinToast Console Example", text = NULL, imagePath = NULL;
     std::vector<std::wstring> actions;
     INT64 expiration = 0;
+    bool onlyCreateShortcut = false;
 
     int i;
     for (i = 1; i < argc; i++)
@@ -64,6 +65,8 @@ int wmain(int argc, LPWSTR *argv)
             appName = argv[++i];
         else if (!wcscmp(L"-app-user-model-id", argv[i]) || !wcscmp(L"-app-id", argv[i]))
             appUserModelID = argv[++i];
+        else if (!wcscmp(L"-only-create-shortcut", argv[i]))
+            onlyCreateShortcut = true;
         else if (argv[i][0] == L'-') {
             std::wcout << L"Unhandled option: " << argv[i] << std::endl;
             return 7;
@@ -77,6 +80,18 @@ int wmain(int argc, LPWSTR *argv)
 
     WinToast::instance()->setAppName(appName);
     WinToast::instance()->setAppUserModelId(appUserModelID);
+    if (onlyCreateShortcut) {
+        if (imagePath || text || actions.size() > 0 || expiration) {
+            std::wcerr << L"-only-create-shortcut does not accept images/text/actions/expiration" << std::endl;
+            return 9;
+        }
+        enum WinToast::ShortcutResult result = WinToast::instance()->createShortcut();
+        return result ? 16 + result : 0;
+    }
+
+    if (!text)
+        text = L"Hello, world!";
+
     if (!WinToast::instance()->initialize()) {
         std::wcerr << L"Error, your system in not compatible!" << std::endl;
         return 9;

--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -50,7 +50,7 @@ int wmain(int argc, LPWSTR *argv)
 
     LPWSTR appName = L"Console WinToast Example", appUserModelID = L"WinToast Console Example", text = L"Hello, world!", imagePath = NULL;
     std::vector<std::wstring> actions;
-    INT64 expiration;
+    INT64 expiration = 0;
 
     int i;
     for (i = 1; i < argc; i++)

--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -102,7 +102,7 @@ int wmain(int argc, LPWSTR *argv)
     }
 
     // Give the handler a chance for 15 seconds (or the expiration plus 1 second)
-    Sleep(expiration ? expiration + 1000 : 15000);
+    Sleep(expiration ? (DWORD)expiration + 1000 : 15000);
 
     exit(2);
 }

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -509,7 +509,7 @@ INT64 WinToast::showToast(_In_ const WinToastTemplate& toast, _In_  IWinToastHan
             const int actionsCount = toast.actionsCount();
             WCHAR buf[12];
             for (int i = 0; i < actionsCount && SUCCEEDED(hr); i++) {
-                _swprintf(buf, L"%d", i);
+                _snwprintf_s(buf, sizeof(buf) / sizeof(*buf), _TRUNCATE, L"%d", i);
                 hr = addActionHelper(toast.actionLabel(i), buf);
             }
             DEBUG_MSG("xml: " << Util::AsString(_xmlDocument));

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -421,9 +421,8 @@ HRESULT	WinToast::validateShellLinkHelper() {
                     if (SUCCEEDED(hr)) {
                         WCHAR AUMI[MAX_PATH];
                         hr = DllImporter::PropVariantToString(appIdPropVar, AUMI, MAX_PATH);
-                        if (SUCCEEDED(hr)) {
-                            hr = (_aumi == AUMI) ? S_OK : E_FAIL;
-                        } else { // AUMI Changed for the same app, let's update the current value! =)
+                        if (FAILED(hr) || _aumi != AUMI) {
+                            // AUMI Changed for the same app, let's update the current value! =)
                             PropVariantClear(&appIdPropVar);
                             hr = InitPropVariantFromString(_aumi.c_str(), &appIdPropVar);
                             if (SUCCEEDED(hr)) {

--- a/src/wintoastlib.h
+++ b/src/wintoastlib.h
@@ -99,6 +99,18 @@ namespace WinToastLib {
         inline std::wstring     appUserModelId() const { return _aumi; }
         void                    setAppUserModelId(_In_ const std::wstring& appName);
         void                    setAppName(_In_ const std::wstring& appName);
+
+        enum ShortcutResult {
+            SHORTCUT_UNCHANGED = 0,
+            SHORTCUT_WAS_CHANGED = 1,
+            SHORTCUT_WAS_CREATED = 2,
+
+            SHORTCUT_MISSING_PARAMETERS = -1,
+            SHORTCUT_INCOMPATIBLE_OS = -2,
+            SHORTCUT_COM_INIT_FAILURE = -3,
+            SHORTCUT_CREATE_FAILED = -4
+        };
+        virtual enum ShortcutResult createShortcut();
     protected:
         bool											_isInitialized;
         bool                                            _hasCoInitialized;
@@ -111,7 +123,7 @@ namespace WinToastLib {
         ComPtr<IToastNotificationFactory>               _notificationFactory;
         static WinToast*								_instance;
 
-        HRESULT     validateShellLinkHelper();
+        HRESULT     validateShellLinkHelper(_Out_ bool& wasChanged);
         HRESULT		createShellLinkHelper();
         HRESULT		setImageFieldHelper(_In_ const std::wstring& path);
         HRESULT     setTextFieldHelper(_In_ const std::wstring& text, _In_ int pos);


### PR DESCRIPTION
This should serve as a better way to address the problem described in #14: that the toast notification is not necessarily shown during the first run of the program, as the shortcut has been *just* created and Windows does not really pick up on it just yet.

This PR is intended to be merged after #16 (it includes those commits, as it would otherwise result in a merge conflict).