### PR TITLE
Add attribution text

### DIFF
--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -144,7 +144,7 @@ int wmain(int argc, LPWSTR *argv)
     }
 
     bool withImage = (imagePath != NULL);
-	WinToastTemplate templ( withImage ? WinToastTemplate::ImageAndText01 : WinToastTemplate::Text01);
+	WinToastTemplate templ( withImage ? WinToastTemplate::ImageAndText02 : WinToastTemplate::Text02);
 	templ.setTextField(text, WinToastTemplate::FirstLine);
     
 	for (auto const &action : actions)
@@ -159,6 +159,8 @@ int wmain(int argc, LPWSTR *argv)
     // WinToastTemplate.setAudioPath(), must be ms-appx:// or ms-appdata:// path.
     //
     templ.setAudioOption(WinToastTemplate::AudioOption::Silent);
+
+    templ.setAttributionText(L"via SMS");
 
     if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {
         std::wcerr << L"Could not launch your toast notification!";

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -711,6 +711,7 @@ HRESULT WinToast::setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ con
             }
         }
     }
+    return hr;
 }
 
 HRESULT WinToast::setTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& text, _In_ int pos) {

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -302,9 +302,9 @@ namespace Util {
         return hr;
     }
 
-    inline HRESULT createElement(_In_ IXmlDocument *xml, _In_ const std::wstring& element_name, _In_ const std::vector<std::wstring>& attribute_names) {
+    inline HRESULT createElement(_In_ IXmlDocument *xml, _In_ const std::wstring& root_node, _In_ const std::wstring& element_name, _In_ const std::vector<std::wstring>& attribute_names) {
         ComPtr<IXmlNodeList> rootList;
-        HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"toast").Get(), &rootList);
+        HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(root_node).Get(), &rootList);
         if (SUCCEEDED(hr)) {
             ComPtr<IXmlNode> root;
             hr = rootList->Item(0, &root);
@@ -576,6 +576,14 @@ INT64 WinToast::showToast(_In_ const WinToastTemplate& toast, _In_  IWinToastHan
                     for (int i = 0; i < fieldsCount && SUCCEEDED(hr); i++) {
                         hr = setTextFieldHelper(xmlDocument.Get(), toast.textField(WinToastTemplate::TextField(i)), i);
                     }
+                    //
+                    // Note that we do this *after* using toast.textFieldsCount() to
+                    // iterate/fill the template's text fields, since we're adding
+                    // yet another text field.
+                    //
+                    if (!toast.attributionText().empty()) {
+                        hr = setAttributionTextFieldHelper(xmlDocument.Get(), toast.attributionText());
+                    }
                     bool modernActions = supportActions();
                     if (!modernActions) DEBUG_MSG("Modern Actions not supported in this os version");
                     if (SUCCEEDED(hr) && modernActions) {
@@ -665,6 +673,45 @@ void WinToast::clear() {
     _buffer.clear();
 }
 
+//
+// Available as of Windows 10 Anniversary Update
+// Ref: https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/adaptive-interactive-toasts
+//
+// NOTE: This will add a new text field, so be aware when iterating over
+//       the toast's text fields or getting a count of them.
+//
+HRESULT WinToast::setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& text) {
+    Util::createElement(xml, L"binding", L"text", { L"placement" });
+    ComPtr<IXmlNodeList> nodeList;
+    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"text").Get(), &nodeList);
+    if (SUCCEEDED(hr)) {
+        UINT32 nodeListLength;
+        hr = nodeList->get_Length(&nodeListLength);
+        if (SUCCEEDED(hr)) {
+            for (UINT32 i = 0; i < nodeListLength; i++) {
+                ComPtr<IXmlNode> textNode;
+                hr = nodeList->Item(i, &textNode);
+                if (SUCCEEDED(hr)) {
+                    ComPtr<IXmlNamedNodeMap> attributes;
+                    hr = textNode->get_Attributes(&attributes);
+                    if (SUCCEEDED(hr)) {
+                        ComPtr<IXmlNode> editedNode;
+                        if (SUCCEEDED(hr)) {
+                            hr = attributes->GetNamedItem(WinToastStringWrapper(L"placement").Get(), &editedNode);
+                            if (FAILED(hr) || !editedNode) {
+                                continue;
+                            }
+                            hr = Util::setNodeStringValue(L"attribution", editedNode.Get(), xml);
+                            if (SUCCEEDED(hr)) {
+                                return setTextFieldHelper(xml, text, i);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 
 HRESULT WinToast::setTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& text, _In_ int pos) {
     ComPtr<IXmlNodeList> nodeList;
@@ -710,7 +757,7 @@ HRESULT WinToast::setAudioFieldHelper(_In_ IXmlDocument *xml, _In_ const std::ws
     if (!path.empty()) attrs.push_back(L"src");
     if (option == WinToastTemplate::AudioOption::Loop) attrs.push_back(L"loop");
     if (option == WinToastTemplate::AudioOption::Silent) attrs.push_back(L"silent");
-    Util::createElement(xml, L"audio", attrs);
+    Util::createElement(xml, L"toast", L"audio", attrs);
 
     ComPtr<IXmlNodeList> nodeList;
     HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"audio").Get(), &nodeList);
@@ -837,6 +884,10 @@ void WinToastTemplate::setAudioPath(_In_ const std::wstring& audioPath) {
 
 void WinToastTemplate::setAudioOption(_In_ const WinToastTemplate::AudioOption & audioOption) {
     _audioOption = audioOption;
+}
+
+void WinToastTemplate::setAttributionText(_In_ const std::wstring& attributionText) {
+    _attributionText = attributionText;
 }
 
 void WinToastTemplate::addAction(const std::wstring & label)

--- a/src/wintoastlib.h
+++ b/src/wintoastlib.h
@@ -64,6 +64,7 @@ namespace WinToastLib {
         void                                        setImagePath(_In_ const std::wstring& imgPath);
         void                                        setAudioPath(_In_ const std::wstring& audioPath);
         void                                        setAudioOption(_In_ const WinToastTemplate::AudioOption& audioOption);
+        void                                        setAttributionText(_In_ const std::wstring & attributionText);
         void                                        addAction(_In_ const std::wstring& label);
         inline void                                 setExpiration(_In_ INT64 millisecondsFromNow) { _expiration = millisecondsFromNow; }
         inline int                                  textFieldsCount() const { return static_cast<int>(_textFields.size()); }
@@ -74,6 +75,7 @@ namespace WinToastLib {
         inline std::wstring                         actionLabel(_In_ int pos) const { return _actions[pos]; }
         inline std::wstring                         imagePath() const { return _imagePath; }
         inline std::wstring                         audioPath() const { return _audioPath; }
+        inline std::wstring                         attributionText() const { return _attributionText; }
         inline INT64                                expiration() const { return _expiration; }
         inline WinToastTemplateType                 type() const { return _type; }
         inline WinToastTemplate::AudioOption        audioOption() const { return _audioOption; }
@@ -86,6 +88,7 @@ namespace WinToastLib {
         INT64                               _expiration;
         WinToastTemplateType                _type;
         WinToastTemplate::AudioOption       _audioOption = WinToastTemplate::AudioOption::None;
+        std::wstring                        _attributionText;
     };
 
     class WinToast {
@@ -133,6 +136,7 @@ namespace WinToastLib {
         HRESULT		setImageFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& path);
         HRESULT     setAudioFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& path, _In_opt_ WinToastTemplate::AudioOption option = WinToastTemplate::AudioOption::None);
         HRESULT     setTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& text, _In_ int pos);
+        HRESULT     setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& text);
         HRESULT     addActionHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& action, _In_ const std::wstring& arguments);
 		ComPtr<IToastNotifier> WinToast::notifier(_In_ bool* succeded) const;
     };


### PR DESCRIPTION
Re: #25 and dependent on #26.

This feature adds an additional text field with the `placement="attribution"` option set, which puts it in a subdued gray color, next to your application's name. This is where you often see "via SMS" or something similar. Here's an example from an [MSDN blog post](https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/adaptive-interactive-toasts).

![image](https://user-images.githubusercontent.com/4247887/35200950-ee564c96-fedb-11e7-9560-e26473208dbb.png)

This required a change to the `Util::createElement()` function introduced in #26, allowing you to specify the root node (by the not-necessarily-unique text name, so not robust, but we're not building an XML parser here, right?) below which the new element is created (`<audio>` goes under `<toast>` but `<text>` goes under `<binding>`).