### PR TITLE
Error initialization on initialization

### DIFF
--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -434,6 +434,7 @@ enum WinToast::ShortcutResult WinToast::createShortcut() {
 
 bool WinToast::initialize(_Out_ WinToastError* error) {
     _isInitialized = false;
+    setError(error, WinToastError::NoError);
 
     if (!isCompatible()) {
         setError(error, WinToastError::SystemNotSupported);


### PR DESCRIPTION
In opposite to showToast, the returned error code was not set on initialization if no error occurred.