### PR TITLE
Fix memory leak in showToast

### DIFF
--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -172,7 +172,7 @@ int wmain(int argc, LPWSTR *argv)
         templ.setImagePath(imagePath);
 
 
-    if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {
+    if (WinToast::instance()->showToast(templ, std::make_unique<CustomHandler>()) < 0) {
         std::wcerr << L"Could not launch your toast notification!";
 		return Results::ToastFailed;
     }

--- a/example/qt-gui-example/WinToastExample/mainwindow.cpp
+++ b/example/qt-gui-example/WinToastExample/mainwindow.cpp
@@ -88,7 +88,7 @@ void MainWindow::on_showToast_clicked()
     if (ui->addNo->isChecked()) templ.addAction(L"No");
 
 
-    if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {
+    if (WinToast::instance()->showToast(templ, std::make_unique<CustomHandler>()) < 0) {
         QMessageBox::warning(this, "Error", "Could not launch your toast notification!");
     }
 }

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -621,7 +621,7 @@ HRESULT	WinToast::createShellLinkHelper() {
     return hr;
 }
 
-INT64 WinToast::showToast(_In_ const WinToastTemplate& toast, _In_  IWinToastHandler* handler, _Out_ WinToastError* error)  {
+INT64 WinToast::showToast(_In_ const WinToastTemplate& toast, _In_ std::unique_ptr<IWinToastHandler> handler, _Out_ WinToastError* error)  {
     setError(error, WinToastError::NoError);
     INT64 id = -1;
     if (!isInitialized()) {
@@ -695,7 +695,7 @@ INT64 WinToast::showToast(_In_ const WinToastTemplate& toast, _In_  IWinToastHan
                                 }
 
                                 if (SUCCEEDED(hr)) {
-                                    hr = Util::setEventHandlers(notification.Get(), std::shared_ptr<IWinToastHandler>(handler), expiration);
+                                    hr = Util::setEventHandlers(notification.Get(), std::shared_ptr<IWinToastHandler>(handler.release()), expiration);
                                     if (FAILED(hr)) {
                                         setError(error, WinToastError::InvalidHandler);
                                     }

--- a/src/wintoastlib.h
+++ b/src/wintoastlib.h
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <vector>
 #include <map>
+#include <memory>
 using namespace Microsoft::WRL;
 using namespace ABI::Windows::Data::Xml::Dom;
 using namespace ABI::Windows::Foundation;
@@ -186,7 +187,7 @@ namespace WinToastLib {
         virtual bool initialize(_Out_ WinToastError* error = nullptr);
         virtual bool isInitialized() const;
         virtual bool hideToast(_In_ INT64 id);
-        virtual INT64 showToast(_In_ const WinToastTemplate& toast, _In_ IWinToastHandler* handler, _Out_ WinToastError* error = nullptr);
+        virtual INT64 showToast(_In_ const WinToastTemplate& toast, _In_ std::unique_ptr<IWinToastHandler> handler, _Out_ WinToastError* error = nullptr);
         virtual void clear();
         virtual enum ShortcutResult createShortcut();
 


### PR DESCRIPTION
showToast only frees the handler when there is no error. This pull request fixes it by using an std::unique_ptr as an input parameter for the handler so that it will be freed in each case.