### PR TITLE
Resource management upgrade

### DIFF
--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -172,7 +172,7 @@ int wmain(int argc, LPWSTR *argv)
         templ.setImagePath(imagePath);
 
 
-    if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {
+    if (WinToast::instance()->showToast(templ, std::make_unique<CustomHandler>()) < 0) {
         std::wcerr << L"Could not launch your toast notification!";
 		return Results::ToastFailed;
     }

--- a/example/qt-gui-example/WinToastExample/mainwindow.cpp
+++ b/example/qt-gui-example/WinToastExample/mainwindow.cpp
@@ -88,7 +88,7 @@ void MainWindow::on_showToast_clicked()
     if (ui->addNo->isChecked()) templ.addAction(L"No");
 
 
-    if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {
+    if (WinToast::instance()->showToast(templ, std::make_unique<CustomHandler>()) < 0) {
         QMessageBox::warning(this, "Error", "Could not launch your toast notification!");
     }
 }

--- a/src/wintoastlib.h
+++ b/src/wintoastlib.h
@@ -24,6 +24,7 @@
 #include <sdkddkver.h>
 #include <WinUser.h>
 #include <ShObjIdl.h>
+#include <atlbase.h>
 #include <wrl/implements.h>
 #include <wrl/event.h>
 #include <windows.ui.notifications.h>
@@ -200,7 +201,7 @@ namespace WinToastLib {
         bool                                            _hasCoInitialized{false};
         std::wstring                                    _appName{};
         std::wstring                                    _aumi{};
-        std::map<INT64, ComPtr<IToastNotification>>     _buffer{};
+        std::map<INT64, CComPtr<IToastNotification>>     _buffer{};
 
         HRESULT validateShellLinkHelper(_Out_ bool& wasChanged);
         HRESULT createShellLinkHelper();
@@ -210,7 +211,7 @@ namespace WinToastLib {
         HRESULT setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& text);
         HRESULT addActionHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& action, _In_ const std::wstring& arguments);
         HRESULT addDurationHelper(_In_ IXmlDocument *xml, _In_ const std::wstring& duration);
-        ComPtr<IToastNotifier> notifier(_In_ bool* succeded) const;
+        CComPtr<IToastNotifier> notifier(_In_ bool* succeded) const;
         void setError(_Out_ WinToastError* error, _In_ WinToastError value);
     };
 }


### PR DESCRIPTION
Hi.

I made this change that makes use of **C**ComPtr instead of the regular ComPtr.
According to [this documentation](https://docs.microsoft.com/en-us/windows/win32/LearnWin32/com-coding-practices#com-smart-pointers) it is the proper way to handle cleanly ComObj without doing the cleanup manually.

Also, I found that calling clear() in the WinToast destructor fixed some crashing in the cleanup procedures. It could fix some of the currently listed issues.

Thanks