### PR TITLE
Making WintoastLib more flexible when accessing the application.lnk

### DIFF
--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -140,6 +140,7 @@ int wmain(int argc, LPWSTR *argv)
 
     WinToast::instance()->setAppName(appName);
     WinToast::instance()->setAppUserModelId(appUserModelID);
+    WinToast::instance()->setCustomShellLinkPath(L"d:\\temp\\");
 
     if (onlyCreateShortcut) {
         if (imagePath || text || actions.size() > 0 || expiration) {

--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -140,7 +140,7 @@ int wmain(int argc, LPWSTR *argv)
 
     WinToast::instance()->setAppName(appName);
     WinToast::instance()->setAppUserModelId(appUserModelID);
-    WinToast::instance()->setCustomShellLinkPath(L"d:\\temp\\");
+    //WinToast::instance()->setCustomShellLinkPath(L"d:\\temp\\");
 
     if (onlyCreateShortcut) {
         if (imagePath || text || actions.size() > 0 || expiration) {

--- a/src/wintoastlib.h
+++ b/src/wintoastlib.h
@@ -194,6 +194,7 @@ namespace WinToastLib {
         const std::wstring& appUserModelId() const;
         void setAppUserModelId(_In_ const std::wstring& aumi);
         void setAppName(_In_ const std::wstring& appName);
+        void setCustomShellLinkPath(_In_ const std::wstring& customShellLinkPath);
 
     protected:
         bool											_isInitialized{false};
@@ -201,6 +202,7 @@ namespace WinToastLib {
         std::wstring                                    _appName{};
         std::wstring                                    _aumi{};
         std::map<INT64, ComPtr<IToastNotification>>     _buffer{};
+        std::wstring                                    _customShellLinkPath;
 
         HRESULT validateShellLinkHelper(_Out_ bool& wasChanged);
         HRESULT createShellLinkHelper();


### PR DESCRIPTION
At the moment the wintoast lib tries to find / create an <application>.lnk in %APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\. 
We found out that this could lead to problems in enterprise environments with strongly restricted rights for user. In our special case the Programs folder (within the Start Menu) doesn't exist at all.

So I added a function to set the folder, where to create the <application>.lnk.  
--> WinToast::setCustomShellLinkPath()

e.g. `WinToast::setCustomShellLinkPath(L"%APPDATA%\\<MyApplication>\\");`

If the customShellLinkPath is not set, the default path is used instead.

Besides this I added some debug messages to `validateShellLinkHelper` and `createShellLinkHelper`.