### PR TITLE
Fixed broken link in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ if (!WinToast::instance()->showToast(templ, handler)) {
 }
 ```
 
-Shao Voon Wong wrote an excellent article about the usage of WinToast. You can find it [here](https://www.codeproject.com/Articles/1151733/WinToast-Toast-Notification-Library-for-Windows-10).
+Shao Voon Wong wrote an excellent article about the usage of WinToast. You can find it [here](https://www.codeproject.com/Articles/5286393/Cplusplus-Windows-Toast-Notification).
 
 ## Installation
 


### PR DESCRIPTION
The link to the article about using WinToast by Shao Voon Wong lead to a wrong article