### PR TITLE
Specify maximum tested CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...3.27)
 project(wintoastlib VERSION 1.3.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Currently, when using the library through CMake 3.27 or later, you'll get a warning similar to this:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 will be removed from a future version of CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.
```

This PR specifies the CMake version as `3.5...3.27`, meaning that at least 3.5 is required, but the project was tested on 3.27 and compatibility with older versions isn't required (see [cmake_minimum_required](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)) - this doesn't set an upper bound for CMake versions.