### PR TITLE
Make WinToast::Instance() thread local

### DIFF
--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -388,7 +388,7 @@ namespace Util {
 } // namespace Util
 
 WinToast* WinToast::instance() {
-    static WinToast instance;
+    thread_local static WinToast instance;
     return &instance;
 }
 


### PR DESCRIPTION
With this, the Instance method returns a thread local instance, instead of a global instance.
This allows using the method inside multi-threaded programs.

Without the *thread_local* keyword, creating a toast inside another thread then the instanciating thread will throw an exception, because the combaselib does not support operation across threads.