### PR TITLE
Update WinToastHandlerExample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ class WinToastHandlerExample : public IWinToastHandler {
 	WinToastHandlerExample(); 
 	// Public interfaces
 	void toastActivated() const override;
+	void toastActivated(int actionIndex) const override;
 	void toastDismissed(WinToastDismissalReason state) const override;
 	void toastFailed() const override;
  };


### PR DESCRIPTION
Added _"void toastActivated(int actionIndex) const override;"_ to the **WinToastHandlerExample** class code snippet.

Not adding this line when setting this up causes an error "C2259 'WinToastHandlerExample': cannot instantiate abstract class" when initialising a new *handler.