### PR TITLE
adding new simple example + fixing mistake in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ Microsoft style guidelines recommend representing profile pictures with a circul
 WinToastTemplate templ = WinToastTemplate(WinToastTemplate::ImageAndText02);
 templ.setTextField(L"Matt sent you a friend request", WinToastTemplate::FirstLine);
 templ.setTextField(L"Hey, wanna dress up as wizards and ride around on hoverboards?", WinToastTemplate::SecondLine);
-templ.setImagePath(L"C:/example.png");
-templ.setHintCrop(WinToastTemplate::Circle);
+templ.setImagePath(L"C:/example.png", WinToastTemplate::CropHint::Circle);
 ```
 
 !["Toast with hero image"](assets/images/hint-crop.png)

--- a/examples/Simple-Explained-console-example/Project1.vcxproj
+++ b/examples/Simple-Explained-console-example/Project1.vcxproj
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{3101ec78-73cc-4e75-8694-775ac5265c76}</ProjectGuid>
+    <RootNamespace>Project1</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="src\main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/examples/Simple-Explained-console-example/Project1.vcxproj.filters
+++ b/examples/Simple-Explained-console-example/Project1.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/examples/Simple-Explained-console-example/Project1.vcxproj.user
+++ b/examples/Simple-Explained-console-example/Project1.vcxproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ShowAllFiles>true</ShowAllFiles>
+  </PropertyGroup>
+</Project>

--- a/examples/Simple-Explained-console-example/src/main.cpp
+++ b/examples/Simple-Explained-console-example/src/main.cpp
@@ -1,0 +1,194 @@
+#include "wintoastlib.h"
+#include <string>
+#include <windows.h>
+
+using namespace WinToastLib;
+
+
+/* Explaine
+    This used to Handle events that occure on users behaves 
+*/
+class CustomHandler : public IWinToastHandler {
+public:
+
+    // When user clicks the notification
+    void toastActivated() const {
+        std::wcout << L"The user clicked in this toast" << std::endl;
+        exit(0);
+    }
+
+    // When user clicks the button in notiification
+    void toastActivated(int actionIndex) const {
+        std::wcout << L"The user clicked on action #" << actionIndex << std::endl;
+        exit(16 + actionIndex);
+    }
+
+    // When user closes the notification
+    void toastDismissed(WinToastDismissalReason state) const {
+        switch (state) {
+        case UserCanceled:
+            std::wcout << L"The user dismissed this toast" << std::endl;
+            exit(1);
+            break;
+        case TimedOut:
+            std::wcout << L"The toast has timed out" << std::endl;
+            exit(2);
+            break;
+        case ApplicationHidden:
+            std::wcout << L"The application hid the toast using ToastNotifier.hide()" << std::endl;
+            exit(3);
+            break;
+        default:
+            std::wcout << L"Toast not activated" << std::endl;
+            exit(4);
+            break;
+        }
+    }
+
+    // When error occure
+    void toastFailed() const {
+        std::wcout << L"Error showing current toast" << std::endl;
+        exit(5);
+    }
+};
+
+// ######################################################################################
+
+
+/* Explaine
+    Here we return code foreach case, to can do any handiling in the future based on the returning code
+*/
+enum Results {
+    ToastClicked,             // user clicked on the toast
+    ToastDismissed,           // user dismissed the toast
+    ToastTimeOut,             // toast timed out
+    ToastHided,               // application hid the toast
+    ToastNotActivated,        // toast was not activated
+    ToastFailed,              // toast failed
+    SystemNotSupported,       // system does not support toasts
+    UnhandledOption,          // unhandled option
+    MultipleTextNotSupported, // multiple texts were provided
+    InitializationFailure,    // toast notification manager initialization failure
+    ToastNotLaunched          // toast could not be launched
+};
+
+
+// ######################################################################################
+
+
+int basicModel() {
+    
+    /* Explaine
+        Here we put all data to our notification properties
+    */
+    std::wstring appName = L"This is Model 1";
+    std::wstring appUserModelID = L"Example 1";
+    std::wstring text1 = L"This is a Test notification";
+    std::wstring text2 = L"Hellow forom C++ I'm the potato who ate the cotato";
+    std::wstring text3 = L"Meow";
+    std::wstring imagePath = L"C:/Users/pc/Downloads/New FCI Hashira/FCIH/FCAIHHPNgLogo.png";
+    std::wstring bannerPath = L"C:/Users/pc/Downloads/New FCI Hashira/Registeration opens (4).png";
+    std::wstring audioPath = L"C:/Users/pc/Downloads/videoplayback.m4a";
+    std::wstring attribute = L"Via SMS";
+    std::vector<std::wstring> actions;
+    INT64 expiration = 70000;
+
+    actions.push_back(L"Cancel");
+    actions.push_back(L"Mute");
+    actions.push_back(L"Answer");
+
+
+    // ######################################################################################
+
+
+    /* Explaine
+        Here we Set the notification settings for the instance
+    */
+
+    WinToastTemplate::AudioOption audioOption = WinToastTemplate::AudioOption::Loop; // set how notification audio should behave
+    
+    /* here we can choose the scenario */
+    //WinToastTemplate::Scenario scenarioOption = WinToastTemplate::Scenario::Default; // for calls
+    //WinToastTemplate::Scenario scenarioOption = WinToastTemplate::Scenario::Alarm; // for alarms
+    //WinToastTemplate::Scenario scenarioOption = WinToastTemplate::Scenario::Reminder; // for Reminder
+    WinToastTemplate::Scenario scenarioOption = WinToastTemplate::Scenario::IncomingCall;
+
+    /* here we can choose the image crop options */
+    //WinToastTemplate::CropHint cropOption = WinToastTemplate::CropHint::Circle; // circle 50%;
+    WinToastTemplate::CropHint cropOption = WinToastTemplate::CropHint::Square; // square
+
+
+    WinToast::instance()->setAppName(appName); // adding the instance name 
+    WinToast::instance()->setAppUserModelId(appUserModelID); // adding the instance id 
+
+
+    if (!WinToast::instance()->initialize()) { // Initialize toast instance, and if error happened return error
+        std::wcerr << L"Error, your system in not compatible!" << std::endl;
+        return Results::InitializationFailure; // if failed will return failure code
+    }
+
+
+    // ######################################################################################
+
+
+    /* Explaine
+        Initialize template from the same instance, this templte is used onece thin killed 
+    */
+
+    WinToastTemplate templ( WinToastTemplate::ImageAndText04); // decide our template type
+    templ.setTextField(text1, WinToastTemplate::FirstLine);
+    templ.setTextField(text2, WinToastTemplate::SecondLine);
+    templ.setTextField(text3, WinToastTemplate::ThirdLine);
+    
+
+    // audio options are sounds differ based on Scenario
+    templ.setAudioOption(audioOption);
+
+
+    // image
+    templ.setImagePath(imagePath); // to set image as icon no crop
+    templ.setImagePath(imagePath, cropOption); // to set how image will be cropped
+
+    // banner
+    templ.setHeroImagePath(bannerPath); // to set image as banner
+    templ.setHeroImagePath(bannerPath, true);
+    templ.setAttributionText(attribute);
+
+
+    templ.setExpiration(expiration);
+    templ.setScenario(scenarioOption);
+
+    for (auto const& action : actions) {
+        templ.addAction(action);
+    }
+
+
+    // ######################################################################################
+
+
+    // Try to send the instance, If failed it will return the Failing Code
+    if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {
+        std::wcerr << L"Could not launch your toast notification!";
+        return Results::ToastFailed;
+    }
+
+    // Give the handler a chance for 7 seconds and in expiration, then the notifcation is killed
+    Sleep((DWORD)expiration + 1500);
+
+    return 2;
+}
+
+
+int model1() {
+    return 0;
+}
+int model2() {
+    return 0;
+}
+
+
+
+int wmain(int argc, LPWSTR* argv) {
+    basicModel();    
+    exit(2); // same as reutrn 2
+}


### PR DESCRIPTION
`WinToastTemplate::Circle` was duplicate to `WinToastTemplate::CropHint::Circle`
And I added new simple example to make it easier to new users to deal with the library

