### PR TITLE
fix: initialize `_hasInput`

### DIFF
--- a/include/wintoastlib.h
+++ b/include/wintoastlib.h
@@ -161,7 +161,7 @@ namespace WinToastLib {
         bool isInput() const;
 
     private:
-        bool _hasInput;
+        bool _hasInput{false};
 
         std::vector<std::wstring> _textFields{};
         std::vector<std::wstring> _actions{};


### PR DESCRIPTION
The member `_hasInput` was never initialized (probably the cause of https://github.com/Chatterino/chatterino2/issues/5907).