### PR TITLE
fix: pass raw input response as wide string

### DIFF
--- a/examples/console-example/CMakeLists.txt
+++ b/examples/console-example/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS /ENTRY:wmainCRTStartup")
-add_executable(WinToastTuiExample WIN32 main.cpp)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:wmainCRTStartup")
+add_executable(WinToastTuiExample main.cpp)
 target_link_libraries(WinToastTuiExample PRIVATE WinToast)
-set_target_properties(WinToastTuiExample PROPERTIES WIN32_EXECUTABLE ON)

--- a/examples/console-example/main.cpp
+++ b/examples/console-example/main.cpp
@@ -16,8 +16,9 @@ public:
         exit(16 + actionIndex);
     }
 
-    void toastActivated(const char* response) const {
-        std::wcout << L"The user clicked on action #" << response << std::endl;
+    void toastActivated(std::wstring response) const {
+        std::wcout << L"The user replied with: " << response << std::endl;
+        exit(0);
     }
 
     void toastDismissed(WinToastDismissalReason state) const {
@@ -72,6 +73,7 @@ enum Results {
 #define COMMAND_SHORTCUT   L"--only-create-shortcut"
 #define COMMAND_AUDIOSTATE L"--audio-state"
 #define COMMAND_ATTRIBUTE  L"--attribute"
+#define COMMAND_INPUT      L"--input"
 
 void print_help() {
     std::wcout << "WinToast Console Example [OPTIONS]" << std::endl;
@@ -85,6 +87,7 @@ void print_help() {
     std::wcout << "\t" << COMMAND_ATTRIBUTE << L" : set the attribute for the notification" << std::endl;
     std::wcout << "\t" << COMMAND_SHORTCUT << L" : create the shortcut for the app" << std::endl;
     std::wcout << "\t" << COMMAND_AUDIOSTATE << L" : set the audio state: Default = 0, Silent = 1, Loop = 2" << std::endl;
+    std::wcout << "\t" << COMMAND_INPUT << L" : add an input to the toast" << std::endl;
     std::wcout << "\t" << COMMAND_HELP << L" : Print the help description" << std::endl;
 }
 
@@ -106,6 +109,7 @@ int wmain(int argc, LPWSTR* argv) {
     std::wstring attribute      = L"default";
     std::vector<std::wstring> actions;
     INT64 expiration = 0;
+    bool input       = false;
 
     bool onlyCreateShortcut                   = false;
     WinToastTemplate::AudioOption audioOption = WinToastTemplate::AudioOption::Default;
@@ -130,6 +134,8 @@ int wmain(int argc, LPWSTR* argv) {
             onlyCreateShortcut = true;
         } else if (!wcscmp(COMMAND_AUDIOSTATE, argv[i])) {
             audioOption = static_cast<WinToastTemplate::AudioOption>(std::stoi(argv[++i]));
+        } else if (!wcscmp(COMMAND_INPUT, argv[i])) {
+            input = true;
         } else if (!wcscmp(COMMAND_HELP, argv[i])) {
             print_help();
             return 0;
@@ -165,6 +171,9 @@ int wmain(int argc, LPWSTR* argv) {
     templ.setAudioOption(audioOption);
     templ.setAttributionText(attribute);
     templ.setImagePath(imagePath);
+    if (input) {
+        templ.addInput();
+    }
 
     for (auto const& action : actions) {
         templ.addAction(action);

--- a/examples/qt-gui-example/mainwindow.cpp
+++ b/examples/qt-gui-example/mainwindow.cpp
@@ -69,8 +69,8 @@ public:
         std::wcout << L"The user clicked on button #" << actionIndex << L" in this toast" << std::endl;
     }
 
-    void toastActivated(const char* response) const {
-        std::wcout << L"The user clicked on action #" << response << std::endl;
+    void toastActivated(std::wstring response) const {
+        std::wcout << L"The user replied with: " << response << std::endl;
     }
 
     void toastFailed() const {
@@ -113,6 +113,10 @@ void MainWindow::on_showToast_clicked() {
 
     if (ui->addNo->isChecked()) {
         templ.addAction(L"No");
+    }
+
+    if (ui->addInput->isChecked()) {
+        templ.addInput();
     }
 
     if (WinToast::instance()->showToast(templ, new CustomHandler()) < 0) {

--- a/examples/qt-gui-example/mainwindow.ui
+++ b/examples/qt-gui-example/mainwindow.ui
@@ -110,6 +110,13 @@
       </property>
      </widget>
     </item>
+    <item row="15" column="0">
+     <widget class="QCheckBox" name="addInput">
+      <property name="text">
+       <string>Add Input</string>
+      </property>
+     </widget>
+    </item>
     <item row="11" column="1">
      <widget class="QLabel" name="label_4">
       <property name="text">
@@ -117,7 +124,7 @@
       </property>
      </widget>
     </item>
-    <item row="15" column="2">
+    <item row="16" column="2">
      <widget class="QWidget" name="widget_2" native="true">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <property name="leftMargin">

--- a/include/wintoastlib.h
+++ b/include/wintoastlib.h
@@ -63,7 +63,7 @@ namespace WinToastLib {
         virtual ~IWinToastHandler()                                      = default;
         virtual void toastActivated() const                              = 0;
         virtual void toastActivated(int actionIndex) const               = 0;
-        virtual void toastActivated(const char* response) const          = 0;
+        virtual void toastActivated(std::wstring response) const         = 0;
         virtual void toastDismissed(WinToastDismissalReason state) const = 0;
         virtual void toastFailed() const                                 = 0;
     };

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -333,17 +333,11 @@ namespace Util {
                                                 hr = propertyValue->GetString(&userInput);
 
                                                 // Convert the HSTRING to a wide string
-                                                PCWSTR strValueW = AsString(userInput);
-
-                                                // Convert the wide string to a STL std::string to pass it as parameter
-                                                // into the event.
-                                                std::wstring ogWstr(strValueW);
-                                                std::string str(ogWstr.length(), ' ');
-                                                std::copy(ogWstr.begin(), ogWstr.end(), str.begin());
+                                                PCWSTR strValue = AsString(userInput);
 
                                                 if (SUCCEEDED(hr))
                                                 {
-                                                    eventHandler->toastActivated(str.c_str());
+                                                    eventHandler->toastActivated(std::wstring(strValue));
                                                     return S_OK;
                                                 }
                                             }


### PR DESCRIPTION
The input didn't handle UTF-16 to UTF-8 conversion properly - it truncated the bytes. Since we get the input as UTF-16, we should propagate it as such. I previously added a proper conversion from UTF-16 to UTF-8, but since this library uses wide strings everywhere, it's only natural to use them here too.

Semi-related changes:

**Console Example**
- Added `--input`
- Turned the executable into a true console app instead of a GUI app (subsystem console)
- Added an exit upon receiving a reply

**Qt Example**
- Added an "Add Input" checkbox

I tested this with the input `hello 😂😂😂😂` and verified that it prints correctly in the terminal (I used VS Code's terminal and MS terminal). This might not display correctly in CMD, so Microsoft's new Terminal has to be used. When testing the Qt version, set `$Env:QT_WIN_DEBUG_CONSOLE="attach"` (powershell), so the app prints to the parent console.