### PR TITLE
Add a way to control debug output during runtime

### DIFF
--- a/include/wintoastlib.h
+++ b/include/wintoastlib.h
@@ -52,6 +52,8 @@ using namespace Windows::Foundation;
 
 namespace WinToastLib {
 
+    void setDebugOutputEnabled(bool enabled);
+
     class IWinToastHandler {
     public:
         enum WinToastDismissalReason {

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -32,24 +32,31 @@
 #pragma comment(lib, "shlwapi")
 #pragma comment(lib, "user32")
 
-#ifdef NDEBUG
-#    define DEBUG_MSG(str)                                                                                                                 \
-        do {                                                                                                                               \
-        } while (false)
-#else
-#    define DEBUG_MSG(str)                                                                                                                 \
-        do {                                                                                                                               \
-            std::wcout << str << std::endl;                                                                                                \
-        } while (false)
-#endif
-
 #define DEFAULT_SHELL_LINKS_PATH L"\\Microsoft\\Windows\\Start Menu\\Programs\\"
 #define DEFAULT_LINK_FORMAT      L".lnk"
 #define STATUS_SUCCESS           (0x00000000)
 
+#ifdef NDEBUG
+static bool DebugOutputEnabled = false;
+#else
+static bool DebugOutputEnabled = true;
+#endif
+
+#define DEBUG_MSG(str)                                                                                                                     \
+    do {                                                                                                                                   \
+        if (DebugOutputEnabled) {                                                                                                          \
+            std::wcout << str << std::endl;                                                                                                \
+        }                                                                                                                                  \
+    } while (false)
+
 // Quickstart: Handling toast activations from Win32 apps in Windows 10
 // https://blogs.msdn.microsoft.com/tiles_and_toasts/2015/10/16/quickstart-handling-toast-activations-from-win32-apps-in-windows-10/
 using namespace WinToastLib;
+
+void WinToastLib::setDebugOutputEnabled(bool enabled) {
+    DebugOutputEnabled = enabled;
+}
+
 namespace DllImporter {
 
     // Function load a function from library


### PR DESCRIPTION
Sometimes it is desirable to see output in release and hide it debug builds. Now this behavior is controlled by a global variable instead of `NDEBUG` preprocessor constant.